### PR TITLE
Load sub scenes

### DIFF
--- a/GFTool.Core/Flatbuffers/TR/Scene/Components/SubScene.cs
+++ b/GFTool.Core/Flatbuffers/TR/Scene/Components/SubScene.cs
@@ -1,0 +1,18 @@
+﻿using FlatSharp.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GFTool.Core.Flatbuffers.TR.Scene.Components
+{
+    [FlatBufferTable]
+    public class SubScene
+    {
+        [FlatBufferItem(0)]
+        public string Filepath { get; set; }
+        [FlatBufferItem(1)]
+        public int unk1 { get; set; }
+    }
+}

--- a/TrinitySceneView/Form1.cs
+++ b/TrinitySceneView/Form1.cs
@@ -1,6 +1,5 @@
 using GFTool.Core.Flatbuffers.TR.Scene;
 using SubScene = GFTool.Core.Flatbuffers.TR.Scene.Components.SubScene;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Diagnostics;
 using System.Reflection;
 using System.Security.Cryptography;

--- a/TrinitySceneView/Form1.cs
+++ b/TrinitySceneView/Form1.cs
@@ -1,4 +1,6 @@
 using GFTool.Core.Flatbuffers.TR.Scene;
+using SubScene = GFTool.Core.Flatbuffers.TR.Scene.Components.SubScene;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Diagnostics;
 using System.Reflection;
 using System.Security.Cryptography;
@@ -15,15 +17,26 @@ namespace TrinitySceneView
             InitializeComponent();
         }
 
-        void WalkTrsot(TreeNode node, SceneEntry[] ents) 
+        void WalkTrsot(TreeNode node, SceneEntry[] ents, string filepath) 
         {
             foreach (var ent in ents) 
             {
                 var newnode = node.Nodes.Add(ent.TypeName);
                 if (ent.NestedType.Length > 0)
                     InnerData.Add(newnode, ent);
+                if(ent.TypeName == "SubScene")
+                {
+                    SubScene s = FlatBufferConverter.DeserializeFrom<SubScene>(ent.NestedType);
+                    string path = new Uri(Path.Combine(Path.GetDirectoryName(filepath), s.Filepath).Replace(".trscn", "_1.trscn")).AbsolutePath;
+                    if (File.Exists(path))
+                    {
+                        var trsot = FlatBufferConverter.DeserializeFrom<TrinitySceneObjTemplate>(path);
+                        newnode.Text += "_" + trsot.SceneName;
+                        WalkTrsot(newnode, trsot.SceneObjectList,path);
+                    }
+                }
                 if (ent.SubObjects.Length > 0) 
-                    WalkTrsot(newnode, ent.SubObjects);
+                    WalkTrsot(newnode, ent.SubObjects, filepath);
             }
         }
 
@@ -34,7 +47,7 @@ namespace TrinitySceneView
             sceneView.Nodes.Clear();
             var trsot = FlatBufferConverter.DeserializeFrom<TrinitySceneObjTemplate>(ofd.FileName);
             var tree = new TreeNode(trsot.SceneName);
-            WalkTrsot(tree, trsot.SceneObjectList);
+            WalkTrsot(tree, trsot.SceneObjectList,ofd.FileName);
             sceneView.Nodes.Add(tree);
         }
 


### PR DESCRIPTION
This automatically loads all SubScenes dependent on the original file structure.
Because the games only uses relative paths this heavily uses path traversal so only the original FIle Structure will automatically be recognised.
