### PR TITLE
Modification to pull and use latest hashes_inside_fd.txt from PokeDocs

### DIFF
--- a/GFTool.Core/Cache/GFPakHashCache.cs
+++ b/GFTool.Core/Cache/GFPakHashCache.cs
@@ -10,6 +10,7 @@ namespace Trinity.Core.Cache
     public class GFPakHashCache
     {
         private const string CachePath = "GFPAKHashCache.bin";
+        private const string SupplementalCachePath = "trinity_paths.txt";
         private static Dictionary<ulong, string> Cache = new Dictionary<ulong, string>();
 
         public static void Init(string path = CachePath)
@@ -26,6 +27,22 @@ namespace Trinity.Core.Cache
                     var name = new String(br.ReadChars(length));
                     Cache.TryAdd(hash, name);
                     //Cache.Add(hash, name);
+                }
+            }
+
+            if (File.Exists(SupplementalCachePath))
+            {
+                using (StreamReader stream_reader = new StreamReader(SupplementalCachePath))
+                {
+                    string line;
+
+                    while ((line = stream_reader.ReadLine()) != null)
+                    {
+                        var hash = GFFNV.Hash(line.Replace("\n", ""));
+                        var name = line.Replace("\n", "");
+
+                        Cache.TryAdd(hash, name);
+                    }
                 }
             }
         }

--- a/GFTool.Core/Cache/GFPakHashCache.cs
+++ b/GFTool.Core/Cache/GFPakHashCache.cs
@@ -5,18 +5,48 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+
 namespace Trinity.Core.Cache
 {
     public class GFPakHashCache
     {
         private const string CachePath = "GFPAKHashCache.bin";
-        private const string SupplementalCachePath = "trinity_paths.txt";
+        private const string LatestCachePath = "hashes_inside_fd.txt";
         private static Dictionary<ulong, string> Cache = new Dictionary<ulong, string>();
 
         public static void Init(string path = CachePath)
         {
             Cache = new Dictionary<ulong, string>();
-            if (File.Exists(path)) {
+            if (File.Exists(LatestCachePath))
+            {
+                using (StreamReader streamReader = new StreamReader(LatestCachePath))
+                {
+                    string line;
+                    while ((line = streamReader.ReadLine()) != null)
+                    {
+                        var hashEntry = line.Split(' ');
+                        ulong hash;
+                        string name;
+
+                        if (hashEntry.Length == 2 && !string.IsNullOrEmpty(hashEntry[0]) && !string.IsNullOrEmpty(hashEntry[1]))
+                        {
+                            try
+                            {
+                                hash = Convert.ToUInt64(hashEntry[0], 16);
+                                name = hashEntry[1].TrimEnd('\r', '\n');
+                            }
+                            catch
+                            {
+                                continue;
+                            }
+
+                            Cache.TryAdd(hash, name);
+                        }
+                    }
+                }
+            }
+            else if (File.Exists(path)) 
+            {
                 BinaryReader br = new BinaryReader(File.OpenRead(path));
                 var version = br.ReadUInt64();
                 var count = br.ReadUInt32();
@@ -27,22 +57,6 @@ namespace Trinity.Core.Cache
                     var name = new String(br.ReadChars(length));
                     Cache.TryAdd(hash, name);
                     //Cache.Add(hash, name);
-                }
-            }
-
-            if (File.Exists(SupplementalCachePath))
-            {
-                using (StreamReader stream_reader = new StreamReader(SupplementalCachePath))
-                {
-                    string line;
-
-                    while ((line = stream_reader.ReadLine()) != null)
-                    {
-                        var hash = GFFNV.Hash(line.Replace("\n", ""));
-                        var name = line.Replace("\n", "");
-
-                        Cache.TryAdd(hash, name);
-                    }
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Trinity Mod Loader requires the oo2core_8_win64.dll and an up-to-date GFPAKHashC
 On initial boot it will ask for your romfs path, once specified the tool will load.
 
 ## Supplemental Hashes
-Placing a file named trinity_hashes.txt in the root directory of TrinityLoader enables the loading of supplemental hashes that may not exist in the current GFPAKHashCache.bin.
+Placing a file named trinity_paths.txt in the root directory of TrinityLoader enables the loading of supplemental hashes that may not exist in the current GFPAKHashCache.bin.
 
 trinity_paths.txt formatting is as follows:
 - One file path per line.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ On initial boot it will ask for your romfs path, once specified the tool will lo
 ## Supplemental Hashes
 Placing a file named trinity_hashes.txt in the root directory of TrinityLoader enables the loading of supplemental hashes that may not exist in the current GFPAKHashCache.bin.
 
-trinity_hashes.txt formatting is as follows:
+trinity_paths.txt formatting is as follows:
 - One file path per line.
 ### Example
 ```

--- a/README.md
+++ b/README.md
@@ -5,17 +5,12 @@ Trinity Mod Loader is a small utility to make and manage mods, while also provid
 Trinity Mod Loader requires the oo2core_8_win64.dll and an up-to-date GFPAKHashCache.bin.
 On initial boot it will ask for your romfs path, once specified the tool will load.
 
-## Supplemental Hashes
-Placing a file named trinity_paths.txt in the root directory of TrinityLoader enables the loading of supplemental hashes that may not exist in the current GFPAKHashCache.bin.
+Trinity Mod Loader will also check if the hashes_inside_fd.txt exists.
+If it does not find this file you will be asked if you want to download the latest hashes.
 
-trinity_paths.txt formatting is as follows:
-- One file path per line.
-### Example
-```
-chara/model_pc/p1_drs1010_s2spring/p1_drs1010_00_drs00.trmdl
-chara/share/cm_drs1010_00_bottoms00_00_alb/cm_drs1010_00_bottoms00_00_alb.bntx
-chara/share/cm_drs1010_00_bottoms00_00_mtl/cm_drs1010_00_bottoms00_00_mtl.bntx
-``` 
+## Updating to the Latest Hashes
+If you need update your hashes you can either delete the existing hashes_inside_fd.txt file and restart Trinity Mod Loader or do the following:
+1. Click ``Help > Get Latest Hashes``
 
 ## Adding a Mod
 1. Add as many mod archive files using the "Add Mod" button. (make sure the contents represent how they would on the romfs)
@@ -28,9 +23,6 @@ chara/share/cm_drs1010_00_bottoms00_00_mtl/cm_drs1010_00_bottoms00_00_mtl.bntx
 3. Once you've tested your mod, zip the modified files in their place in romfs and ship it!
 
 Note: We'll be adding a way to add some mod metadata to keep better track of your mods soon.
-
-
-
 
 ## Source Code
 The canonical repository for this tool and the GFTool.Core which provies serializers for Trinity files can be found at [https://github.com/pkZukan/gftool/](https://github.com/pkZukan/gftool/).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ Trinity Mod Loader is a small utility to make and manage mods, while also provid
 Trinity Mod Loader requires the oo2core_8_win64.dll and an up-to-date GFPAKHashCache.bin.
 On initial boot it will ask for your romfs path, once specified the tool will load.
 
+## Supplemental Hashes
+Placing a file named trinity_hashes.txt in the root directory of TrinityLoader enables the loading of supplemental hashes that may not exist in the current GFPAKHashCache.bin.
+
+trinity_hashes.txt formatting is as follows:
+- One file path per line.
+### Example
+```
+chara/model_pc/p1_drs1010_s2spring/p1_drs1010_00_drs00.trmdl
+chara/share/cm_drs1010_00_bottoms00_00_alb/cm_drs1010_00_bottoms00_00_alb.bntx
+chara/share/cm_drs1010_00_bottoms00_00_mtl/cm_drs1010_00_bottoms00_00_mtl.bntx
+``` 
+
 ## Adding a Mod
 1. Add as many mod archive files using the "Add Mod" button. (make sure the contents represent how they would on the romfs)
 2. When you're done adding mods, simply hit the "Apply Mods" button. This will generate files either in a LayeredFS folder in the same directory as the program, or a directory of your choice if you set an output directory.
@@ -16,6 +28,9 @@ On initial boot it will ask for your romfs path, once specified the tool will lo
 3. Once you've tested your mod, zip the modified files in their place in romfs and ship it!
 
 Note: We'll be adding a way to add some mod metadata to keep better track of your mods soon.
+
+
+
 
 ## Source Code
 The canonical repository for this tool and the GFTool.Core which provies serializers for Trinity files can be found at [https://github.com/pkZukan/gftool/](https://github.com/pkZukan/gftool/).

--- a/TrinityModLoader/TrinityMainWindow.Designer.cs
+++ b/TrinityModLoader/TrinityMainWindow.Designer.cs
@@ -42,6 +42,7 @@
             this.showUnhashedFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.getLatestHashes = new System.Windows.Forms.ToolStripMenuItem();
             this.fileView = new System.Windows.Forms.TreeView();
             this.helpProvider1 = new System.Windows.Forms.HelpProvider();
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
@@ -169,7 +170,8 @@
             // helpToolStripMenuItem
             // 
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.aboutToolStripMenuItem});
+            this.aboutToolStripMenuItem,
+            this.getLatestHashes});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
             this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
             this.helpToolStripMenuItem.Text = "Help";
@@ -177,9 +179,16 @@
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
+            // 
+            // getLatestHashes
+            // 
+            this.getLatestHashes.Name = "getLatestHashes";
+            this.getLatestHashes.Size = new System.Drawing.Size(180, 22);
+            this.getLatestHashes.Text = "Get Latest Hashes";
+            this.getLatestHashes.Click += new System.EventHandler(this.getLatestHashes_Click);
             // 
             // fileView
             // 
@@ -473,5 +482,6 @@
         private ToolStripMenuItem setOutputFolderToolStripMenuItem;
         private Label versionLbl;
         private Label label4;
+        private ToolStripMenuItem getLatestHashes;
     }
 }


### PR DESCRIPTION
Modified to use hashes_inside_fd.txt as the primary hash source and fail over to the existing distributed GFPAKHashCache.bin if isn't found.

Added a PullLatestHashes method that grabs the latest hashes_inside_fd.txt file from the PokeDocs repo then restarts Trinity Mod Loader.
This method is called on load if the hashes_inside_fd.txt file isn't found in the directory or if the user click the added "Get Latest Hashes" button under the Help menu.

If PullLatestHashes fails out for whatever reason the user is prompted to manually retrieve the file instead and the URL for hashes_inside_fd.txt in PokeDocs is dropped into their clipboard.