### PR TITLE
Fix unhandled exceptions

### DIFF
--- a/TrinityModLoader/TrinityMainWindow.cs
+++ b/TrinityModLoader/TrinityMainWindow.cs
@@ -648,10 +648,14 @@ namespace Trinity
         {
             Point ClickPoint = new Point(e.X, e.Y);
             modList.SelectedIndex = modList.IndexFromPoint(ClickPoint);
-            settings.mods[modList.SelectedIndex].IsChecked = modList.GetItemChecked(modList.SelectedIndex);
-            if (e.Button == MouseButtons.Right && modList.SelectedIndex >= 0) {
-                
-                basicContext.Show(modList, ClickPoint);
+            if (modList.SelectedIndex != -1)
+            {
+                settings.mods[modList.SelectedIndex].IsChecked = modList.GetItemChecked(modList.SelectedIndex);
+                if (e.Button == MouseButtons.Right && modList.SelectedIndex >= 0)
+                {
+
+                    basicContext.Show(modList, ClickPoint);
+                }
             }
         }
 

--- a/TrinityModLoader/TrinityMainWindow.cs
+++ b/TrinityModLoader/TrinityMainWindow.cs
@@ -98,6 +98,9 @@ namespace Trinity
                 settings = JsonSerializer.Deserialize<Settings>(File.ReadAllText(file));
                 disableAutoLoad.Checked = !settings.autoloadTrpfd;
             }
+
+            //clean up missing files
+            settings.mods = settings.mods.Where(m => File.Exists(m.Path)).ToList();
         }
 
         //Populate mods from json


### PR DESCRIPTION
fixes a ArgumentOutOfRange Exception when clicking on the modlist but not on a mod
also removes not found mods from the settings file when mod zips where removed before removing them from the list in the GUI

fixes #8 (and probably #10)